### PR TITLE
correct an invalid reference

### DIFF
--- a/lib/Pub.js
+++ b/lib/Pub.js
@@ -135,7 +135,7 @@ const TwitchPubSub = class TwitchPubSub extends EventEmitter {
       self.emit("disconnect");
 
       clearInterval(heartbeatHandle);
-      setTimeout(this._connect, reconnectInterval);
+      setTimeout(self._connect, reconnectInterval);
     };
   }
 };


### PR DESCRIPTION
In line 138 of Pub.js, "this" is used but it is an error in the function "this" refers to the same function and not to the class